### PR TITLE
VCSWP-15720: Added active property to CallsSearchFilters and Calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 None
+<a name="3.0.3"</a>
+## [3.0.1] 2021-11-4
+### Added
+- 1 new property `active` for CallSearchFilters and Call
 <a name="3.0.1"</a>
 ## [3.0.1] 2021-8-3
 ### Added

--- a/freeclimb-cs-sdk-test/api/call/CallTest.cs
+++ b/freeclimb-cs-sdk-test/api/call/CallTest.cs
@@ -33,6 +33,7 @@ namespace freeclimb_cs_sdk_test.api.call
             Assert.AreEqual(call.getRevision, 1);
             Assert.IsNotNull(call.getDateCreated);
             Assert.IsNotNull(call.getDateUpdated);
+            Assert.IsNotNull(call.getActive);
             Assert.AreEqual(call.getStatus, ECallStatus.Queued);
             Assert.IsNotNull(call.getConnectTime);
             Assert.AreEqual(call.getConnectDuration, 7);

--- a/freeclimb-cs-sdk-test/api/call/CallsRequesterTest.cs
+++ b/freeclimb-cs-sdk-test/api/call/CallsRequesterTest.cs
@@ -56,6 +56,7 @@ namespace freeclimb_cs_sdk_test.api.call
                 Assert.AreEqual(call.getRevision, 1);
                 Assert.IsNotNull(call.getDateCreated);
                 Assert.IsNotNull(call.getDateUpdated);
+                Assert.IsNotNull(call.getActive);
                 Assert.AreEqual(call.getStatus, ECallStatus.Queued);
             }
             catch (FreeClimbException pe)

--- a/freeclimb-cs-sdk/api/call/Call.cs
+++ b/freeclimb-cs-sdk/api/call/Call.cs
@@ -149,7 +149,7 @@ namespace com.freeclimb.api.call
         /// Retrieve  whether the call is active or not from the object.
         /// </summary>
         /// <returns>The active property for this call.</returns>
-        public bool active { get { return this.active; } }
+        public bool getActive { get { return this.active; } }
 
         /// <summary>
         /// Retrieve  the status for this call from the object.

--- a/freeclimb-cs-sdk/api/call/Call.cs
+++ b/freeclimb-cs-sdk/api/call/Call.cs
@@ -55,6 +55,9 @@ namespace com.freeclimb.api.call
         [JsonProperty(PropertyName = "phoneNumberId")]
         private readonly string phoneNumberId;
 
+        [JsonProperty(PropertyName = "active")]
+        private readonly bool active;
+
         [JsonProperty(PropertyName = "status")]
         private readonly ECallStatus status;
 
@@ -89,7 +92,7 @@ namespace com.freeclimb.api.call
 #pragma warning restore 0649 
 
         /// <summary>
-	    /// Helper method to build a Call object from the JSON string.
+        /// Helper method to build a Call object from the JSON string.
         /// </summary>
         /// <param name="rawJson">A JSON string representing a Call instance.</param>
         /// <returns>A Call object equivalent to the JSON string passed in.</returns>
@@ -141,6 +144,12 @@ namespace com.freeclimb.api.call
         /// </summary>
         /// <returns>The phoneNumberId for this call.</returns>
         public string getPhoneNumberId { get { return this.phoneNumberId; } }
+
+        /// <summary>
+        /// Retrieve  whether the call is active or not from the object.
+        /// </summary>
+        /// <returns>The active property for this call.</returns>
+        public bool active { get { return this.active; } }
 
         /// <summary>
         /// Retrieve  the status for this call from the object.
@@ -229,6 +238,7 @@ namespace com.freeclimb.api.call
             hash ^= this.to.GetHashCode();
             hash ^= this.from.GetHashCode();
             hash ^= this.phoneNumberId.GetHashCode();
+            hash ^= this.active.GetHashCode();
             hash ^= this.status.GetHashCode();
             hash ^= this.startTime.GetHashCode();
             hash ^= this.endTime.GetHashCode();
@@ -322,7 +332,7 @@ namespace com.freeclimb.api.call
         }
 
         /// <summary>
-	    /// Helper method to deep compare two Call instances.
+        /// Helper method to deep compare two Call instances.
         /// </summary>
         /// <param name="a">Call instance one.</param>
         /// <param name="b">Call instance two.</param>
@@ -345,6 +355,7 @@ namespace com.freeclimb.api.call
                    String.Equals(a.getTo, b.getTo, StringComparison.Ordinal) &&
                    String.Equals(a.getFrom, b.getFrom, StringComparison.Ordinal) &&
                    String.Equals(a.getPhoneNumberId, b.getPhoneNumberId, StringComparison.Ordinal) &&
+                   (a.getActive == b.getActive) &&
                    (a.getStatus == b.getStatus) &&
                    ((DateTime.Compare(a.getStartTime, b.getStartTime) == 0) ? true : false) &&
                    ((DateTime.Compare(a.getEndTime, b.getEndTime) == 0) ? true : false) &&
@@ -358,3 +369,4 @@ namespace com.freeclimb.api.call
         }
     }
 }
+

--- a/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
+++ b/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
@@ -195,7 +195,7 @@ namespace com.freeclimb.api.call
                 props.Add("parentcallId", getParentCallId);
             }
 
-            if (getActive != Null)
+            if (getActive != null)
             {
                 props.Add("active", getActive);
             }

--- a/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
+++ b/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
@@ -153,13 +153,13 @@ namespace com.freeclimb.api.call
         /// Retrieve the active value.
         /// </summary>
         /// <returns>The active value of the object.</returns>
-        public string getActive { get { return this.active; } }
+        public bool getActive { get { return this.active; } }
 
         /// <summary>
         /// Sets the active object value.
         /// </summary>
         /// <param name="val">active value.</param>
-        public void setActive(string val) { this.active = val; }
+        public void setActive(bool val) { this.active = val; }
 
         /// <summary>
         /// Retrieve the KVP Dictionary for the CallsSearchFilters instance. 
@@ -195,7 +195,7 @@ namespace com.freeclimb.api.call
                 props.Add("parentcallId", getParentCallId);
             }
 
-            if (string.IsNullOrEmpty(active) == false)
+            if (bool.IsNullOrEmpty(active) == false)
             {
                 props.Add("active", active);
             }

--- a/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
+++ b/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
@@ -32,7 +32,7 @@ namespace com.freeclimb.api.call
         private string parentCallId = string.Empty;
 
         [JsonProperty(PropertyName = "active")]
-        private bool active = bool.Null;
+        private bool active = false;
 
         /// <summary>
 	    /// Helper method to build a CallsSearchFilters object from the JSON string.
@@ -195,7 +195,7 @@ namespace com.freeclimb.api.call
                 props.Add("parentcallId", getParentCallId);
             }
 
-            if (active.ToString.IsNullOrEmpty(getActive) == false)
+            if (bool.ToString.IsNullOrEmpty(getActive) == false)
             {
                 props.Add("active", getActive);
             }

--- a/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
+++ b/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
@@ -195,7 +195,7 @@ namespace com.freeclimb.api.call
                 props.Add("parentcallId", getParentCallId);
             }
 
-            if (bool.ToString.IsNullOrEmpty(getActive) == false)
+            if (getActive != Null)
             {
                 props.Add("active", getActive);
             }

--- a/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
+++ b/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
@@ -32,7 +32,7 @@ namespace com.freeclimb.api.call
         private string parentCallId = string.Empty;
 
         [JsonProperty(PropertyName = "active")]
-        private bool active = bool.Empty;
+        private bool active = bool.Null;
 
         /// <summary>
 	    /// Helper method to build a CallsSearchFilters object from the JSON string.
@@ -195,9 +195,9 @@ namespace com.freeclimb.api.call
                 props.Add("parentcallId", getParentCallId);
             }
 
-            if (active != null)
+            if (active.ToString.IsNullOrEmpty(getActive) == false)
             {
-                props.Add("active", active);
+                props.Add("active", getActive);
             }
 
             if (getStatus != ECallStatus.NONE)

--- a/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
+++ b/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
@@ -32,7 +32,7 @@ namespace com.freeclimb.api.call
         private string parentCallId = string.Empty;
 
         [JsonProperty(PropertyName = "active")]
-        private bool active = string.Empty;
+        private bool active = bool.Empty;
 
         /// <summary>
 	    /// Helper method to build a CallsSearchFilters object from the JSON string.

--- a/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
+++ b/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
@@ -31,6 +31,9 @@ namespace com.freeclimb.api.call
         [JsonProperty(PropertyName = "parentcallId")]
         private string parentCallId = string.Empty;
 
+        [JsonProperty(PropertyName = "active")]
+        private bool active = string.Empty;
+
         /// <summary>
 	    /// Helper method to build a CallsSearchFilters object from the JSON string.
         /// </summary>
@@ -147,6 +150,18 @@ namespace com.freeclimb.api.call
         public void setParentCallId(string val) { this.parentCallId = val; }
 
         /// <summary>
+        /// Retrieve the active value.
+        /// </summary>
+        /// <returns>The active value of the object.</returns>
+        public string getActive { get { return this.active; } }
+
+        /// <summary>
+        /// Sets the active object value.
+        /// </summary>
+        /// <param name="val">active value.</param>
+        public void setActive(string val) { this.active = val; }
+
+        /// <summary>
         /// Retrieve the KVP Dictionary for the CallsSearchFilters instance. 
         /// </summary>
         /// <returns>KVP Dictionary</returns>
@@ -178,6 +193,11 @@ namespace com.freeclimb.api.call
             if (string.IsNullOrEmpty(getParentCallId) == false)
             {
                 props.Add("parentcallId", getParentCallId);
+            }
+
+            if (string.IsNullOrEmpty(active) == false)
+            {
+                props.Add("active", active);
             }
 
             if (getStatus != ECallStatus.NONE)

--- a/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
+++ b/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
@@ -197,7 +197,7 @@ namespace com.freeclimb.api.call
 
             if (getActive != null)
             {
-                props.Add("active", getActive);
+                props.Add("active", getActive.ToString());
             }
 
             if (getStatus != ECallStatus.NONE)

--- a/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
+++ b/freeclimb-cs-sdk/api/call/CallsSearchFilters.cs
@@ -158,7 +158,7 @@ namespace com.freeclimb.api.call
         /// <summary>
         /// Sets the active object value.
         /// </summary>
-        /// <param name="val">active value.</param>
+        /// <param name="val">The active value.</param>
         public void setActive(bool val) { this.active = val; }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace com.freeclimb.api.call
                 props.Add("parentcallId", getParentCallId);
             }
 
-            if (bool.IsNullOrEmpty(active) == false)
+            if (active != null)
             {
                 props.Add("active", active);
             }


### PR DESCRIPTION
In the class CallsSearchFilters and Calls, added the variable `private bool active = false;` as well as the corresponding getters and setters. The `active` property should be false by default)